### PR TITLE
Add Skip Locked Flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ var DefaultConfig = Config{
 		User:         "root",
 		Password:     "",
 		MaxOpenConns: 50,
+		SkipLocked:   true,
 	},
 	Listen: listenConfig{
 		Host: "127.0.0.1",
@@ -53,6 +54,7 @@ type mysqlConfig struct {
 	User         string
 	Password     string
 	MaxOpenConns int
+	SkipLocked   bool
 }
 
 func (c mysqlConfig) DSN() string {

--- a/dalga.go
+++ b/dalga.go
@@ -50,6 +50,7 @@ func New(config Config) (*Dalga, error) {
 	log.Println("listening", lis.Addr())
 
 	t := table.New(db, config.MySQL.Table)
+	t.SkipLocked = config.MySQL.SkipLocked
 	i := instance.New(t)
 	s := scheduler.New(t, i.ID(), config.Endpoint.BaseURL, time.Duration(config.Endpoint.Timeout)*time.Second, time.Duration(config.Jobs.RetryInterval)*time.Second, config.Jobs.RandomizationFactor)
 	j := jobmanager.New(t, s)

--- a/dalga_test.go
+++ b/dalga_test.go
@@ -45,6 +45,7 @@ func dropTables(db *sql.DB, table string) error {
 
 func TestSchedule(t *testing.T) {
 	config := DefaultConfig
+	config.MySQL.SkipLocked = false
 
 	db, err := sql.Open("mysql", config.MySQL.DSN())
 	if err != nil {

--- a/internal/table/table.go
+++ b/internal/table/table.go
@@ -12,8 +12,9 @@ import (
 var ErrNotExist = errors.New("job does not exist")
 
 type Table struct {
-	db   *sql.DB
-	name string
+	db         *sql.DB
+	name       string
+	SkipLocked bool
 }
 
 func New(db *sql.DB, name string) *Table {
@@ -128,6 +129,9 @@ func (t *Table) Front(ctx context.Context, instanceID uint32) (*Job, error) {
 		"AND instance_id IS NULL " +
 		"ORDER BY next_run ASC LIMIT 1 " +
 		"FOR UPDATE"
+	if t.SkipLocked {
+		s += " SKIP LOCKED"
+	}
 	row := tx.QueryRowContext(ctx, s)
 	var j Job
 	var interval uint32

--- a/internal/table/table.go
+++ b/internal/table/table.go
@@ -127,7 +127,7 @@ func (t *Table) Front(ctx context.Context, instanceID uint32) (*Job, error) {
 		"WHERE next_run < UTC_TIMESTAMP() " +
 		"AND instance_id IS NULL " +
 		"ORDER BY next_run ASC LIMIT 1 " +
-		"FOR UPDATE SKIP LOCKED"
+		"FOR UPDATE"
 	row := tx.QueryRowContext(ctx, s)
 	var j Job
 	var interval uint32


### PR DESCRIPTION
This PR adds a config option for using the `SKIP LOCKED` clause that is supported by MySql > 8.0 and not in MariaDB.

(I decided to go with a config option rather than a flag, because it made more sense in the codebase and also just more sense in general once I thought about it.)

Closes #5 