### PR TITLE
Mock Time

### DIFF
--- a/internal/table/table.go
+++ b/internal/table/table.go
@@ -14,6 +14,7 @@ var ErrNotExist = errors.New("job does not exist")
 type Table struct {
 	db   *sql.DB
 	name string
+	clk  *Clock
 }
 
 func New(db *sql.DB, name string) *Table {
@@ -83,8 +84,8 @@ func (t *Table) AddJob(ctx context.Context, key Key, interval, delay time.Durati
 	if nextRun.IsZero() {
 		s := "REPLACE INTO " + t.name + // nolint: gosec
 			"(path, body, `interval`, next_run) " +
-			"VALUES (?, ?, ?, UTC_TIMESTAMP() + INTERVAL ? SECOND)"
-		_, err = tx.ExecContext(ctx, s, key.Path, key.Body, interval/time.Second, delay/time.Second)
+			"VALUES (?, ?, ?, IFNULL(?, UTC_TIMESTAMP()) + INTERVAL ? SECOND)"
+		_, err = tx.ExecContext(ctx, s, key.Path, key.Body, interval/time.Second, t.clk.NowUTC(), delay/time.Second)
 	} else {
 		s := "REPLACE INTO " + t.name + // nolint: gosec
 			"(path, body, `interval`, next_run) " +
@@ -124,11 +125,11 @@ func (t *Table) Front(ctx context.Context, instanceID uint32) (*Job, error) {
 	defer tx.Rollback() // nolint: errcheck
 	s := "SELECT path, body, `interval`, next_run " +
 		"FROM " + t.name + " " +
-		"WHERE next_run < UTC_TIMESTAMP() " +
+		"WHERE next_run < IFNULL(?, UTC_TIMESTAMP()) " +
 		"AND instance_id IS NULL " +
 		"ORDER BY next_run ASC LIMIT 1 " +
 		"FOR UPDATE SKIP LOCKED"
-	row := tx.QueryRowContext(ctx, s)
+	row := tx.QueryRowContext(ctx, s, t.clk.NowUTC())
 	var j Job
 	var interval uint32
 	err = row.Scan(&j.Path, &j.Body, &interval, &j.NextRun)
@@ -147,9 +148,9 @@ func (t *Table) Front(ctx context.Context, instanceID uint32) (*Job, error) {
 // UpdateNextRun sets next_run to now+interval.
 func (t *Table) UpdateNextRun(ctx context.Context, key Key, delay time.Duration) error {
 	s := "UPDATE " + t.name + " " + // nolint: gosec
-		"SET next_run=UTC_TIMESTAMP() + INTERVAL ? SECOND, instance_id=NULL " +
+		"SET next_run=IFNULL(?, UTC_TIMESTAMP()) + INTERVAL ? SECOND, instance_id=NULL " +
 		"WHERE path = ? AND body = ?"
-	_, err := t.db.ExecContext(ctx, s, delay/time.Second, key.Path, key.Body)
+	_, err := t.db.ExecContext(ctx, s, t.clk.NowUTC(), delay/time.Second, key.Path, key.Body)
 	return err
 }
 
@@ -171,18 +172,19 @@ func (t *Table) Count(ctx context.Context) (int64, error) {
 // Pending returns the count of pending jobs in the table.
 func (t *Table) Pending(ctx context.Context) (int64, error) {
 	s := "SELECT COUNT(*) FROM " + t.name + " " + // nolint: gosec
-		"WHERE next_run < UTC_TIMESTAMP()"
+		"WHERE next_run < IFNULL(?, UTC_TIMESTAMP())"
 	var count int64
-	return count, t.db.QueryRowContext(ctx, s).Scan(&count)
+	return count, t.db.QueryRowContext(ctx, s, t.clk.NowUTC()).Scan(&count)
 }
 
 // Lag returns the number of seconds passed from the execution time of the oldest pending job.
 func (t *Table) Lag(ctx context.Context) (int64, error) {
-	s := "SELECT TIMESTAMPDIFF(SECOND, next_run, UTC_TIMESTAMP()) FROM " + t.name + " " + // nolint: gosec
-		"WHERE next_run < UTC_TIMESTAMP() AND instance_id is NULL " +
+	s := "SELECT TIMESTAMPDIFF(SECOND, next_run, IFNULL(?, UTC_TIMESTAMP())) FROM " + t.name + " " + // nolint: gosec
+		"WHERE next_run < IFNULL(?, UTC_TIMESTAMP()) AND instance_id is NULL " +
 		"ORDER BY next_run ASC LIMIT 1"
+	now := t.clk.NowUTC()
 	var lag int64
-	err := t.db.QueryRowContext(ctx, s).Scan(&lag)
+	err := t.db.QueryRowContext(ctx, s, now, now).Scan(&lag)
 	if err == sql.ErrNoRows {
 		err = nil
 	}
@@ -205,9 +207,10 @@ func (t *Table) Instances(ctx context.Context) (int64, error) {
 }
 
 func (t *Table) UpdateInstance(ctx context.Context, id uint32) error {
-	s := "INSERT INTO " + t.name + "_instances(id, updated_at) VALUES (" + strconv.FormatUint(uint64(id), 10) + ",UTC_TIMESTAMP()) ON DUPLICATE KEY UPDATE updated_at=UTC_TIMESTAMP()" // nolint: gosec
-	s += ";DELETE FROM " + t.name + "_instances WHERE updated_at < UTC_TIMESTAMP() - INTERVAL 1 MINUTE"                                                                                // nolint: gosec
-	_, err := t.db.ExecContext(ctx, s)
+	s := "INSERT INTO " + t.name + "_instances(id, updated_at) VALUES (" + strconv.FormatUint(uint64(id), 10) + ",IFNULL(?, UTC_TIMESTAMP())) ON DUPLICATE KEY UPDATE updated_at=IFNULL(?, UTC_TIMESTAMP())" // nolint: gosec
+	s += ";DELETE FROM " + t.name + "_instances WHERE updated_at < IFNULL(?, UTC_TIMESTAMP()) - INTERVAL 1 MINUTE"                                                                                           // nolint: gosec
+	now := t.clk.NowUTC()
+	_, err := t.db.ExecContext(ctx, s, now, now, now)
 	return err
 }
 

--- a/internal/table/time.go
+++ b/internal/table/time.go
@@ -1,0 +1,31 @@
+package table
+
+import (
+	"sync"
+	"time"
+)
+
+type Clock struct {
+	t time.Time
+	l sync.RWMutex
+}
+
+func (clk *Clock) Set(t time.Time) {
+	clk.l.Lock()
+	clk.t = t
+	clk.l.Unlock()
+}
+
+func (clk *Clock) Get() time.Time {
+	clk.l.RLock()
+	defer clk.l.RUnlock()
+	return clk.t
+}
+
+func (clk *Clock) NowUTC() *time.Time {
+	if clk == nil {
+		return nil
+	}
+	t := clk.Get().UTC()
+	return &t
+}


### PR DESCRIPTION
Closes #8 

Adds the ability to mock time for the purpose of unit tests.  Uses the `IFNULL(?, UTC_TIMESTAMP())` strategy described in #8.

Depends upon #10 because it will be annoying to unit-test this without a proper Go client 😉 