### PR TITLE
Idempotency

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -23,6 +23,8 @@ func TestClient(t *testing.T) {
 	config := DefaultConfig
 	config.Endpoint.BaseURL = "http://" + srv.Listener.Addr().String()
 	config.MySQL.SkipLocked = false
+	config.Listen.Port = 34007
+	config.MySQL.Table = "test_client"
 	d, lis, cleanup := newDalga(t, config)
 	defer cleanup()
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -122,6 +123,7 @@ func (s *Scheduler) postJob(ctx context.Context, j *table.Job) (code int, err er
 		return
 	}
 	req.Header.Set("content-type", "text/plain")
+	req.Header.Set("dalga-sched", strconv.FormatInt(j.NextSched.Unix(), 10))
 	resp, err := s.client.Do(req)
 	if err != nil {
 		return

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,80 @@
+package scheduler
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/senseyeio/duration"
+
+	"github.com/cenkalti/dalga/v2/internal/instance"
+	"github.com/cenkalti/dalga/v2/internal/table"
+)
+
+var dsn = fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true&multiStatements=true", "root", "", "127.0.0.1", 3306, "test")
+
+// TestSchedHeader verifies that when the scheduler executes a job, the
+// POST includes a header with the unix timestamp of the intended execution.
+//
+// Retries of a particular execution will preserve the timestamp of the
+// original execution, which receivers can use to ensure idempotency.
+func TestSchedHeader(t *testing.T) {
+	rcv := make(chan int64)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hdr := r.Header.Get("dalga-sched")
+		unix, err := strconv.ParseInt(hdr, 10, 64)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		rcv <- unix
+	}))
+
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	interval, err := duration.ParseISO8601("PT1M")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tbl := table.New(db, "sched")
+	if err := tbl.Drop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := tbl.Create(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer tbl.Drop(context.Background())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	i := instance.New(tbl)
+	go i.Run(ctx)
+
+	s := New(tbl, i.ID(), "http://"+srv.Listener.Addr().String()+"/", time.Second, interval, 0, time.Millisecond*250)
+	go s.Run(ctx)
+
+	nextRun := time.Now().Add(time.Second).UTC()
+	_, err = tbl.AddJob(context.Background(), table.Key{Path: "abc", Body: "def"}, duration.Duration{}, duration.Duration{}, time.UTC, nextRun)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case unix := <-rcv:
+		if expect := nextRun.Unix(); unix != expect {
+			t.Fatalf("Expected unix %d and found %d", expect, unix)
+		}
+	case <-time.After(time.Second * 2):
+		t.Fatal("Job never fired.")
+	}
+}

--- a/recur_test.go
+++ b/recur_test.go
@@ -149,6 +149,7 @@ func TestRecur(t *testing.T) {
 	config.Jobs.FixedIntervals = true
 	config.Jobs.ScanFrequency = 100
 	config.Endpoint.BaseURL = "http://" + srv.Listener.Addr().String() + "/"
+	config.Listen.Port = 34008
 
 	d, lis, cleanup := newDalga(t, config)
 	defer cleanup()


### PR DESCRIPTION
When the scheduler executes a job, the POST includes a header with the unix timestamp of the intended execution.  Retries of a particular execution will preserve the timestamp of the original execution, which receivers can use to ensure idempotency.

When running tests, was having some clashes over the port, so I tweaked them throughout the codebase.

Note that I called it `dalga-sched` rather than `dalga-next-sched` because from the receiver's perspective, it's the timestamp that job was scheduled to run at.

Closes #17 