### PR TITLE
Cluster Tests

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -153,7 +153,7 @@ func TestClusterSuccession(t *testing.T) {
 		config.Jobs.FixedIntervals = true
 		config.Jobs.ScanFrequency = 100 * time.Millisecond
 		config.Endpoint.BaseURL = "http://" + srv.Listener.Addr().String() + "/"
-		config.Listen.Port = 34100 + i
+		config.Listen.Port = 34200 + i
 
 		d, lis, cleanup := newDalga(t, config)
 		instances[i] = d

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1,0 +1,95 @@
+package dalga
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestCluster(t *testing.T) {
+
+	called := make(chan string)
+	endpoint := func(w http.ResponseWriter, r *http.Request) {
+		var buf bytes.Buffer
+		buf.ReadFrom(r.Body)
+		r.Body.Close()
+		called <- buf.String()
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", endpoint)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	numInstances := 3
+	var client *Client
+	instances := make([]*Dalga, numInstances)
+	for i := 0; i < numInstances; i++ {
+		config := DefaultConfig
+		config.MySQL.SkipLocked = false
+		config.MySQL.Table = "test_cluster"
+		config.Jobs.FixedIntervals = true
+		config.Jobs.ScanFrequency = 100 * time.Millisecond
+		config.Endpoint.BaseURL = "http://" + srv.Listener.Addr().String() + "/"
+		config.Listen.Port = 34100 + i
+
+		d, lis, cleanup := newDalga(t, config)
+		instances[i] = d
+		if i == 0 {
+			client = NewClient("http://" + lis.Addr())
+		}
+		defer cleanup()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	for _, inst := range instances {
+		go inst.Run(ctx)
+	}
+	defer func() {
+		cancel()
+		for _, inst := range instances {
+			<-inst.NotifyDone()
+		}
+	}()
+
+	// This is a fairly crude test which attempts to ensure that,
+	// with several instances running at once, two instances will not
+	// grab the same job and execute it.  It's hardly a Jepsen test,
+	// more of a basic sanity check.
+	t.Run("run at most once", func(t *testing.T) {
+
+		start := time.Now().Add(time.Second)
+		jobCount := 100
+		received := make(map[string]bool, jobCount)
+		for i := 0; i < jobCount; i++ {
+			key := fmt.Sprintf("job%d", i)
+			_, err := client.Schedule(ctx, "apple", key, WithFirstRun(start), WithOneOff())
+			if err != nil {
+				t.Fatal(err)
+			}
+			received[key] = false
+		}
+
+		for i := 0; i < jobCount; i++ {
+			rcv := <-called
+			if ok := received[rcv]; ok {
+				t.Errorf("Received job %s twice!", rcv)
+			}
+			received[rcv] = true
+		}
+
+		for key, ok := range received {
+			if !ok {
+				t.Errorf("Did not receive job %s", key)
+			}
+		}
+
+		time.Sleep(time.Second)
+
+	})
+
+}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -117,6 +118,124 @@ func TestCluster(t *testing.T) {
 
 		if len(countsByInstance) != len(instances) {
 			t.Fatalf("Expected each instance to have done some jobs.")
+		}
+
+		time.Sleep(time.Second)
+	})
+}
+
+func TestClusterSuccession(t *testing.T) {
+	numInstances := 3
+	instances := make([]*Dalga, numInstances)
+	ctxes := make([]context.Context, numInstances)
+	cancels := make([]func(), numInstances)
+	for i := 0; i < numInstances; i++ {
+		ctxes[i], cancels[i] = context.WithCancel(context.Background())
+	}
+	killStart, killDone := make(chan string), make(chan string)
+	kill := func(w http.ResponseWriter, r *http.Request) {
+		instance := r.Header.Get("dalga-instance")
+		killStart <- instance
+		killDone <- instance
+		w.WriteHeader(200)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/kill", kill)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	var client *Client
+	for i := 0; i < numInstances; i++ {
+		config := DefaultConfig
+		config.MySQL.SkipLocked = false
+		config.MySQL.Table = "test_cluster_succession"
+		config.Jobs.FixedIntervals = true
+		config.Jobs.ScanFrequency = 100 * time.Millisecond
+		config.Endpoint.BaseURL = "http://" + srv.Listener.Addr().String() + "/"
+		config.Listen.Port = 34100 + i
+
+		d, lis, cleanup := newDalga(t, config)
+		instances[i] = d
+		if i == 0 {
+			client = NewClient("http://" + lis.Addr())
+		}
+		defer cleanup()
+	}
+
+	for i, inst := range instances {
+		go inst.Run(ctxes[i])
+	}
+	defer func() {
+		for i, inst := range instances {
+			if fn := cancels[i]; fn != nil {
+				fn()
+			}
+			<-inst.NotifyDone()
+		}
+	}()
+
+	t.Run("reclaim jobs", func(t *testing.T) {
+		start := time.Now().Add(time.Second)
+		_, err := client.Schedule(context.Background(), "kill", "bill", WithFirstRun(start), WithOneOff())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// An instance is going to run the job.
+		var doomedInstance string
+		select {
+		case doomedInstance = <-killStart:
+		case <-time.After(time.Second * 2):
+			t.Fatal("Didn't get the kill start")
+		}
+
+		// Now we kill it before the cycle of action completes.
+		t.Logf("Killing instance %s", doomedInstance)
+		id, err := strconv.ParseUint(doomedInstance, 10, 32)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var done chan struct{}
+		for i, inst := range instances {
+			if inst.instance.ID() == uint32(id) {
+				done = inst.NotifyDone()
+				cancels[i]()
+				cancels[i] = nil
+				break
+			}
+		}
+		if done == nil {
+			t.Fatalf("Couldn't locate instance with id %d", id)
+		}
+		select {
+		case <-done:
+		case <-time.After(time.Second * 2):
+			t.Fatal("Didn't get the done signal from the dead Dalga")
+		}
+		select {
+		case <-killDone:
+		case <-time.After(time.Second * 2):
+			t.Fatal("Didn't finish the kill")
+		}
+
+		// Now, another instance will pick up that job and try again.
+		var replacement string
+		select {
+		case replacement = <-killStart:
+		case <-time.After(time.Second * 2):
+			t.Fatal("Job wasn't picked up by a replacement instance")
+		}
+		if replacement == doomedInstance {
+			t.Fatal("Something is very wrong")
+		}
+		select {
+		case finished := <-killDone:
+			if finished != replacement {
+				t.Fatalf("Something else is very wrong, finished is '%s' but should be '%s'", finished, replacement)
+			}
+		case <-time.After(time.Second * 2):
+			t.Fatal("Job was never finished")
 		}
 
 		time.Sleep(time.Second)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1,4 +1,4 @@
-package dalga
+package dalga // nolint: testpackage
 
 import (
 	"bytes"
@@ -11,7 +11,6 @@ import (
 )
 
 func TestCluster(t *testing.T) {
-
 	called := make(chan struct {
 		body     string
 		instance string
@@ -67,7 +66,6 @@ func TestCluster(t *testing.T) {
 	// grab the same job and execute it.  It's hardly a Jepsen test,
 	// more of a basic sanity check.
 	t.Run("run at most once", func(t *testing.T) {
-
 		start := time.Now().Add(time.Second)
 		jobCount := 100
 		received := make(map[string]bool, jobCount)
@@ -95,11 +93,9 @@ func TestCluster(t *testing.T) {
 		}
 
 		time.Sleep(time.Second)
-
 	})
 
 	t.Run("distributed amongst instances", func(t *testing.T) {
-
 		start := time.Now().Add(time.Second)
 		jobCount := 99
 		countsByInstance := map[string]int{}
@@ -124,7 +120,5 @@ func TestCluster(t *testing.T) {
 		}
 
 		time.Sleep(time.Second)
-
 	})
-
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40
+	github.com/go-mysql/errors v0.0.0-20180603193453-03314bea68e0
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/knadh/koanf v0.12.1
 	github.com/senseyeio/duration v0.0.0-20180430131211-7c2a214ada46

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/go-mysql/errors v0.0.0-20180603193453-03314bea68e0 h1:meiLwrW6ukHHehydhoDxVHdQKQe7TFgEpH0A0hHBAWs=
+github.com/go-mysql/errors v0.0.0-20180603193453-03314bea68e0/go.mod h1:ZH8V0509n2OSZLMYTMHzcy4hqUB+rG8ghK1zsP4i5gE=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -122,6 +122,7 @@ func (s *Scheduler) postJob(ctx context.Context, j *table.Job) (code int, err er
 	}
 	req.Header.Set("content-type", "text/plain")
 	req.Header.Set("dalga-sched", j.NextSched.Format(time.RFC3339))
+	req.Header.Set("dalga-instance", fmt.Sprintf("%d", s.instanceID))
 	resp, err := s.client.Do(req)
 	if err != nil {
 		return


### PR DESCRIPTION
Some basic sanity checks that a cluster behaves how one would expect:

- Jobs run only once.
- Jobs are spread out amongst the instances.
- A job can be reclaimed

Closes #15 

As a bonus, I instituted a retry mechanism for `Table.UpdateNextRun()` because it was deadlocking in tests and causing them to fail.  I don't know that there's a way around the deadlocks given how things are implemented, but the advice wrt deadlocks is to retry it, so that's what I did.  Makes the code more robust in any case because it will spot transient network anomalies and retry those as well.

The retry capability could be added to the rest of the calls but this isn't the point of the PR so I haven't done that.

Also, I added a `dalga-instance` header to POSTed jobs, with the ID of what instance is running the job.  This was needed for these tests but might come in handy otherwise (debugging, logging, etc.)